### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,10 +11,10 @@ Stopwatch	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 Reset	KEYWORD2
-Update KEYWORD2
+Update	KEYWORD2
 GetElapsed	KEYWORD2
-GetFrequency KEYWORD2
-Measure KEYWORD2
+GetFrequency	KEYWORD2
+Measure	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords