### PR TITLE
Update millis() gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Librería Arduino Stopwatch
-Librería para Arduino que permite registrar el tiempo transcurrido en la ejecución del código, obteniendo el resultado como milisegundos transcurridos o como frecuencia en Hz. Con esta librería podemos medir el tiempo de forma sencilla, liberando de estas funciones al flujo principal.
+Librería para Arduino que permite registrar el tiempo transcurrido en la ejecución del código, obteniendo el resultado como microsegundos transcurridos o como frecuencia en Hz. Con esta librería podemos medir el tiempo de forma sencilla, liberando de estas funciones al flujo principal.
 
 Más información https://www.luisllamas.es/libreria-arduino-stopwatch/
 
@@ -10,7 +10,7 @@ La clase Stopwatch dispone de dos modos de funcionamiento. Uno es mediante el us
 
 El otro modo de funcionamiento es mediante el uso de la función `Measure()`, que recibe como parámetro una funcion `void(*)()` para medir. Stopwatch registra el tiempo empleado para la ejecución de la función pasada como parámetro. 
 
-En cualquiera de los dos casos, el tiempo registrado se obtiene mediante `GetElapsed()` y `GetFrequency()` que obtienen, respectivamente, el tiempo en milisegundos y la frecuencia en Hz.
+En cualquiera de los dos casos, el tiempo registrado se obtiene mediante `GetElapsed()` y `GetFrequency()` que obtienen, respectivamente, el tiempo en microsegundos y la frecuencia en Hz.
 
 ### Constructor
 ```c++
@@ -19,6 +19,9 @@ Stopwatch();
 
 ### Usar Stopwatch
 ```c++
+// Auto tuning without parameter, manual if pass a parameter
+void Tune();
+
 // Registra el instante actual como comienzo de la medición
 void Reset();
  
@@ -28,7 +31,7 @@ void Update();
 // Registra la medición de la función pasada como parámetro
 void Measure(StopwatchAction action);
  
-// Obtiene el tiempo transcurrido en milisegundos
+// Obtiene el tiempo transcurrido en microsegundos
 unsigned long GetElapsed() const;
  
 // Obtiene el tiempo transcurrido como frecuencia en Hz
@@ -46,6 +49,8 @@ Stopwatch stopwatch;
 void setup()
 {
 	Serial.begin(9600);
+	// Set microseconds gap between Reset and Update calls
+	stopwatch.Tune(2);
 }
 
 void loop()
@@ -70,6 +75,8 @@ Stopwatch stopwatch;
 void setup()
 {
 	Serial.begin(9600);
+	// Automatic calculation of gap between Reset and Update calls
+	stopwatch.Tune();
 }
 
 void loop()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Stopwatch();
 ### Usar Stopwatch
 ```c++
 // Auto tuning without parameter, manual if pass a parameter
-void Tune();
+void Tune(unsigned long tune);
 
 // Registra el instante actual como comienzo de la medición
 void Reset();

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,10 +11,11 @@ Stopwatch	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 Reset	KEYWORD2
-Update	KEYWORD2
-GetElapsed	KEYWORD2
-GetFrequency	KEYWORD2
+Update KEYWORD2
+GetElapsed KEYWORD2
+GetFrequency KEYWORD2
 Measure	KEYWORD2
+Tune KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/StopwatchLib.cpp
+++ b/src/StopwatchLib.cpp
@@ -40,3 +40,23 @@ void Stopwatch::Measure(StopwatchAction action)
 	action();
 	Update();
 }
+
+void Stopwatch::Tune(unsigned int tune)
+{
+	_tuning = tune;
+}
+
+void Stopwatch::Tune()
+{
+	unsigned long t1, tdelta, lower = ~0UL;
+	//test the millis timings (autotune)
+	for(int i=0;i<100;i++){
+		t1 = micros();
+		micros();
+		tdelta = micros() - t1;
+		if( tdelta < lower ){
+			lower = tdelta;
+		}
+	}
+	_tuning = lower;
+}

--- a/src/StopwatchLib.cpp
+++ b/src/StopwatchLib.cpp
@@ -41,7 +41,7 @@ void Stopwatch::Measure(StopwatchAction action)
 	Update();
 }
 
-void Stopwatch::Tune(unsigned int tune)
+void Stopwatch::Tune(unsigned long tune)
 {
 	_tuning = tune;
 }

--- a/src/StopwatchLib.h
+++ b/src/StopwatchLib.h
@@ -29,7 +29,7 @@ public:
 	float GetFrequency() const;
 
 	void Measure(StopwatchAction action);
-	void Tune(unsigned int tune);
+	void Tune(unsigned long tune);
 	void Tune();
 private:
 	unsigned long _lastMicros;

--- a/src/StopwatchLib.h
+++ b/src/StopwatchLib.h
@@ -29,11 +29,12 @@ public:
 	float GetFrequency() const;
 
 	void Measure(StopwatchAction action);
-
+	void Tune(unsigned int tune);
+	void Tune();
 private:
 	unsigned long _lastMicros;
 	unsigned long _elapsed;
-	const unsigned int _tuning = 8;
+	unsigned int _tuning = 0;
 };
 
 #endif

--- a/src/StopwatchLib.h
+++ b/src/StopwatchLib.h
@@ -34,7 +34,7 @@ public:
 private:
 	unsigned long _lastMicros;
 	unsigned long _elapsed;
-	unsigned int _tuning = 0;
+	unsigned long _tuning = 0;
 };
 
 #endif


### PR DESCRIPTION
Hi Luis,

I updated your very good Arduino library with the Tune() function that auto-tune the gap of millis() call.
I did this because my Sparkfun Pro Micro have a minimum gap of only 4 microseconds instead of 8.


I hope this can be a helpful update.

Cheers